### PR TITLE
Live Downloads Page

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,9 +18,9 @@
             <a href="#about">About</a>
             <a href="#faq">FAQ</a>
             <a href="#todo">To do</a>
-            <a class="cont-sec">____________</a>
+            <a style="padding-top: none; padding-bottom: none;">____________</a>
             <a href="pages/wiki.html">Wiki</a>
-            <a href="pages/download.html">Latest Builds</a>
+            <a href="pages/downloads.html">Latest Builds</a>
         </div>
     </div>
     <div id="link_tray">

--- a/index.html
+++ b/index.html
@@ -18,7 +18,9 @@
             <a href="#about">About</a>
             <a href="#faq">FAQ</a>
             <a href="#todo">To do</a>
+            <a>____________</a>
             <a href="pages/wiki.html">Wiki</a>
+            <a href="pages/download.html">Latest Builds</a>
         </div>
     </div>
     <div id="link_tray">

--- a/index.html
+++ b/index.html
@@ -15,10 +15,6 @@
     <div class="dropdown" onmouseenter="toggleDropdown(true)" onmouseleave="toggleDropdown(false)">
         <button class="dropbtn">Menu</button>
         <div class="dropdown-content" id="dropdownContent">
-            <a href="#about">About</a>
-            <a href="#faq">FAQ</a>
-            <a href="#todo">To do</a>
-            <a style="padding-top: none; padding-bottom: none;">____________</a>
             <a href="pages/wiki.html">Wiki</a>
             <a href="pages/downloads.html">Latest Builds</a>
         </div>

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
             <a href="#about">About</a>
             <a href="#faq">FAQ</a>
             <a href="#todo">To do</a>
-            <a>____________</a>
+            <a class="cont-sec">____________</a>
             <a href="pages/wiki.html">Wiki</a>
             <a href="pages/download.html">Latest Builds</a>
         </div>

--- a/public/pages/downloads.css
+++ b/public/pages/downloads.css
@@ -1,0 +1,24 @@
+body {
+    font-family: 'Ubuntu', sans-serif;
+}
+
+#bbcon {
+  margin: 12px auto;
+}
+
+.build-button {
+  background-color: #111111;
+  color: white;
+  padding: 12px 17px;
+  font-size: 16px;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  display: inline;
+  margin: 12px auto;
+  font-family: 'Ubuntu', sans-serif;
+
+.build-button:hover,
+.build-button:focus {
+  background-color: #333333;
+}

--- a/public/pages/downloads.css
+++ b/public/pages/downloads.css
@@ -17,8 +17,7 @@ body {
   display: inline;
   margin: 12px auto;
   font-family: 'Ubuntu', sans-serif;
-  position: absolute;
-  margin-right: 12px;
+  z-index: 1;
 }
 
 .build-button:hover,
@@ -47,6 +46,7 @@ body {
 .dropbdown {
   font-family: 'Ubuntu', sans-serif;
   display: inline;
+  z-index: 999;
 }
 
 .dropbdown-content {

--- a/public/pages/downloads.css
+++ b/public/pages/downloads.css
@@ -59,8 +59,7 @@ body {
   transform: scale(0.8);
   transition: opacity 0.3s ease, transform 0.3s ease;
   transform-origin: top;
-  top: calc(33vh + 100vh / 33);
-  position: absolute;
+  position: relative;
 }
 
 @media (max-width: 768px) {

--- a/public/pages/downloads.css
+++ b/public/pages/downloads.css
@@ -59,8 +59,14 @@ body {
   transform: scale(0.8);
   transition: opacity 0.3s ease, transform 0.3s ease;
   transform-origin: top;
-  top: calc((33vh + 100vh / 33) * 2vh);
+  top: calc(33vh + 100vh / 33);
   position: absolute;
+}
+
+@media (max-width: 768px) {
+  .dropbdown-content {
+    top: calc(33vh + 100vh / 33 * 2vh);
+  }
 }
 
 .dropbdown-content a {

--- a/public/pages/downloads.css
+++ b/public/pages/downloads.css
@@ -17,8 +17,76 @@ body {
   display: inline;
   margin: 12px auto;
   font-family: 'Ubuntu', sans-serif;
+}
 
 .build-button:hover,
 .build-button:focus {
   background-color: #333333;
+}
+
+.dropbuild {
+  background-color: #111111;
+  color: white;
+  padding: 12px 17px;
+  font-size: 16px;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  display: inline;
+  position: absolute;
+  left: 0;
+  margin-left: 5px;
+  font-family: 'Ubuntu', sans-serif;
+}
+
+.dropbuild:hover,
+.dropbbuild:focus {
+  background-color: #333333;
+}
+
+.dropbdown {
+  margin-left: 0.5em;
+  left: 0;
+  font-family: 'Ubuntu', sans-serif;
+}
+
+.dropbdown-content {
+  display: none;
+  position: absolute;
+  background-color: #f1f1f1;
+  min-width: 160px;
+  box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
+  z-index: 1;
+  top: 40px;
+  left: 0;
+  border-radius: 10px;
+  opacity: 0;
+  transform: scale(0.8);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  transform-origin: top;
+  margin-top: 10px;
+}
+
+.dropbdown-content a {
+  color: black;
+  padding: 12px 16px;
+  text-decoration: none;
+  display: block;
+  border-radius: 10px;
+}
+
+.dropbdown-content a:hover {
+  background-color: #ddd;
+}
+
+.dropbdown:hover .dropbdown-content {
+  display: block;
+  opacity: 1;
+  transform: scale(1);
+}
+
+.dropbdown:hover .dropbdown-content {
+  display: block;
+  opacity: 1;
+  transform: translateY(10px);
 }

--- a/public/pages/downloads.css
+++ b/public/pages/downloads.css
@@ -62,6 +62,7 @@ body {
   transition: opacity 0.3s ease, transform 0.3s ease;
   transform-origin: top;
   margin-top: 10px;
+  position: absolute;
 }
 
 .dropbdown-content a {

--- a/public/pages/downloads.css
+++ b/public/pages/downloads.css
@@ -18,6 +18,7 @@ body {
   margin: 12px auto;
   font-family: 'Ubuntu', sans-serif;
   position: absolute;
+  margin-right: 12px;
 }
 
 .build-button:hover,
@@ -61,12 +62,6 @@ body {
   transition: opacity 0.3s ease, transform 0.3s ease;
   transform-origin: top;
   position: relative;
-}
-
-@media (max-width: 768px) {
-  .dropbdown-content {
-    top: calc(33vh + 100vh / 33 * 2vh);
-  }
 }
 
 .dropbdown-content a {

--- a/public/pages/downloads.css
+++ b/public/pages/downloads.css
@@ -59,7 +59,7 @@ body {
   transform: scale(0.8);
   transition: opacity 0.3s ease, transform 0.3s ease;
   transform-origin: top;
-  margin-top: 37%;
+  top: calc(27vh + 100vh / 33);
   position: absolute;
 }
 

--- a/public/pages/downloads.css
+++ b/public/pages/downloads.css
@@ -17,7 +17,6 @@ body {
   display: inline;
   margin: 12px auto;
   font-family: 'Ubuntu', sans-serif;
-  z-index: 1;
 }
 
 .build-button:hover,
@@ -61,7 +60,6 @@ body {
   transition: opacity 0.3s ease, transform 0.3s ease;
   transform-origin: top;
   position: relative;
-  z-index: 999;
 }
 
 .dropbdown-content a {

--- a/public/pages/downloads.css
+++ b/public/pages/downloads.css
@@ -59,7 +59,7 @@ body {
   transform: scale(0.8);
   transition: opacity 0.3s ease, transform 0.3s ease;
   transform-origin: top;
-  top: calc(27vh + 100vh / 33);
+  top: calc((33vh + 100vh / 33) * 2vh);
   position: absolute;
 }
 

--- a/public/pages/downloads.css
+++ b/public/pages/downloads.css
@@ -17,6 +17,7 @@ body {
   display: inline;
   margin: 12px auto;
   font-family: 'Ubuntu', sans-serif;
+  position: absolute;
 }
 
 .build-button:hover,

--- a/public/pages/downloads.css
+++ b/public/pages/downloads.css
@@ -46,7 +46,6 @@ body {
 .dropbdown {
   font-family: 'Ubuntu', sans-serif;
   display: inline;
-  z-index: 999;
 }
 
 .dropbdown-content {
@@ -62,6 +61,7 @@ body {
   transition: opacity 0.3s ease, transform 0.3s ease;
   transform-origin: top;
   position: relative;
+  z-index: 999;
 }
 
 .dropbdown-content a {

--- a/public/pages/downloads.css
+++ b/public/pages/downloads.css
@@ -33,7 +33,6 @@ body {
   border-radius: 10px;
   cursor: pointer;
   display: inline;
-  margin-left: 5px;
   font-family: 'Ubuntu', sans-serif;
   display: inline;
 }
@@ -60,7 +59,7 @@ body {
   transform: scale(0.8);
   transition: opacity 0.3s ease, transform 0.3s ease;
   transform-origin: top;
-  margin-top: 10px;
+  margin-top: 100px;
   position: absolute;
 }
 

--- a/public/pages/downloads.css
+++ b/public/pages/downloads.css
@@ -33,8 +33,6 @@ body {
   border-radius: 10px;
   cursor: pointer;
   display: inline;
-  position: absolute;
-  left: 0;
   margin-left: 5px;
   font-family: 'Ubuntu', sans-serif;
   display: inline;
@@ -52,7 +50,6 @@ body {
 
 .dropbdown-content {
   display: none;
-  position: absolute;
   background-color: #f1f1f1;
   min-width: 160px;
   box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);

--- a/public/pages/downloads.css
+++ b/public/pages/downloads.css
@@ -37,6 +37,7 @@ body {
   left: 0;
   margin-left: 5px;
   font-family: 'Ubuntu', sans-serif;
+  display: inline;
 }
 
 .dropbuild:hover,
@@ -45,9 +46,8 @@ body {
 }
 
 .dropbdown {
-  margin-left: 0.5em;
-  left: 0;
   font-family: 'Ubuntu', sans-serif;
+  display: inline;
 }
 
 .dropbdown-content {

--- a/public/pages/downloads.css
+++ b/public/pages/downloads.css
@@ -59,7 +59,7 @@ body {
   transform: scale(0.8);
   transition: opacity 0.3s ease, transform 0.3s ease;
   transform-origin: top;
-  margin-top: 100px;
+  margin-top: 37%;
   position: absolute;
 }
 

--- a/public/pages/downloads.css
+++ b/public/pages/downloads.css
@@ -55,7 +55,6 @@ body {
   box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
   z-index: 1;
   top: 40px;
-  left: 0;
   border-radius: 10px;
   opacity: 0;
   transform: scale(0.8);

--- a/public/pages/downloads.html
+++ b/public/pages/downloads.html
@@ -147,7 +147,7 @@
         if (choice == true) {
             window.location.href = 'https://github.com/Lime3DS/Lime3DS/tree/master?tab=readme-ov-file#android';
         } else {
-            location.href = 'https://lime3ds.vercel.app/pages/downloads.html'
+            window.location.href = 'https://lime3ds.vercel.app/pages/downloads.html'
         }
         const url = await getAssetUrl('-android-universal.apk');
         if (url) {

--- a/public/pages/downloads.html
+++ b/public/pages/downloads.html
@@ -17,7 +17,7 @@
         <button class="dropbtn">Menu</button>
         <div class="dropdown-content" id="dropdownContent">
             <a href="../../index.html">Home</a>
-            <a class="cont-sec">____________</a>
+            <a style="padding-top: none; padding-bottom: none;">____________</a>
             <a href="wiki.html">Wiki</a>
             <a href="downloads.html">Latest Builds</a>
         </div>

--- a/public/pages/downloads.html
+++ b/public/pages/downloads.html
@@ -149,13 +149,13 @@
         } else {
             location.href = 'https://lime3ds.vercel.app/pages/downloads.html'
         }
-        /* const url = await getAssetUrl('-android-universal.apk');
+        const url = await getAssetUrl('-android-universal.apk');
         if (url) {
-            downloadFile(url);
+            // downloadFile(url);
         } else {
             alert('File not found');
         }
-    }); */
+    });
 
     document.getElementById('windowsButton1').addEventListener('click', async () => {
         const url = await getAssetUrl('-windows-msvc.zip');

--- a/public/pages/downloads.html
+++ b/public/pages/downloads.html
@@ -149,13 +149,13 @@
         } else {
             location.href = 'https://lime3ds.vercel.app/pages/downloads.html'
         }
-        const url = await getAssetUrl('-android-universal.apk');
+        /* const url = await getAssetUrl('-android-universal.apk');
         if (url) {
             downloadFile(url);
         } else {
             alert('File not found');
         }
-    });
+    }); */
 
     document.getElementById('windowsButton1').addEventListener('click', async () => {
         const url = await getAssetUrl('-windows-msvc.zip');

--- a/public/pages/downloads.html
+++ b/public/pages/downloads.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Latest Releases</title>
+    <link rel="icon" href="favicon.ico" type="image/x-icon">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Ubuntu&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="downloads.css">
+</head>
+<body>
+<div id="header">
+    <div class="dropdown" onmouseenter="toggleDropdown(true)" onmouseleave="toggleDropdown(false)">
+        <button class="dropbtn">Menu</button>
+        <div class="dropdown-content" id="dropdownContent">
+            <a href="../../index.html">Home</a>
+            <a>____________</a>
+            <a href="pages/wiki.html">Wiki</a>
+            <a href="pages/download.html">Latest Builds</a>
+        </div>
+    </div>
+    <div id="link_tray">
+        <a href="https://github.com/Lime3DS/Lime-3DS-Emulator">GitHub</a> |
+        <a href="https://discord.com/invite/4ZjMpAp3M6">Discord</a> |
+        <a href="https://github.com/Lime3DS/Lime-3DS-Emulator/releases">Releases</a>
+    </div>
+    <div style="position: absolute; right: 5px; top: 5px;" id="container">
+        <img id="container" src="lime/lime.png" alt="Lime">
+        <img id="object" src="lime/face.png" alt="Eyes">
+    </div>
+</div>
+
+<div id="content">
+    <h3 class="index-h3" id="about" style="margin-top: 0em;">Latest Releases</h3>
+    <p>These are Lime3DS' latest releases/builds for the following platforms:</p>
+  <div id="bbcon">
+    <button class="build-button">Android</button>
+    <button class="build-button">Linux</button>
+    <button class="build-button">Windows</button>
+    <button class="build-button">MacOS</button>
+  </div>
+</div>
+<script>
+    // Preload images
+    var images = ['lime/face.png', 'lime/smile.png'];
+    preloadImages(images);
+
+    function preloadImages(array) {
+        if (!preloadImages.list) {
+            preloadImages.list = [];
+        }
+        for (var i = 0; i < array.length; i++) {
+            var img = new Image();
+            img.src = array[i];
+            preloadImages.list.push(img);
+        }
+    }
+
+    function toggleDropdown(open) {
+        var dropdownContent = document.getElementById('dropdownContent');
+        if (open) {
+            dropdownContent.style.display = 'block';
+            setTimeout(function() {
+                dropdownContent.style.opacity = 1;
+                dropdownContent.style.transform = 'scale(1)';
+            }, 10); // Adding a slight delay for smoother animation
+        } else {
+            dropdownContent.style.opacity = 0;
+            dropdownContent.style.transform = 'scale(0.8)';
+            setTimeout(function() {
+                dropdownContent.style.display = 'none';
+            }, 300); // Same duration as the transition in CSS
+        }
+    }
+
+    document.addEventListener('mousemove', function (e) {
+        var object = document.getElementById('object');
+        var container = document.getElementById('container');
+
+        // Calculate the position of the cursor relative to the container
+        var mouseX = e.clientX - container.getBoundingClientRect().left;
+        var mouseY = e.clientY - container.getBoundingClientRect().top;
+
+        // Calculate the position of the eyes relative to the cursor position within the lime container
+        var offsetX = (mouseX - (container.offsetWidth / 2)) * 0.0025; // Adjust the factor to control eye movement
+        var offsetY = (mouseY - (container.offsetHeight / 2)) * 0.0025; // Adjust the factor to control eye movement
+
+        // Set the position of the eyes
+        object.style.left = (container.offsetWidth / 2 - object.offsetWidth / 2 + offsetX) + 'px';
+        object.style.top = (container.offsetHeight / 2 - object.offsetHeight / 2 + offsetY) + 'px';
+    });
+</script>
+</body>
+  </html>

--- a/public/pages/downloads.html
+++ b/public/pages/downloads.html
@@ -39,7 +39,7 @@
   <div id="bbcon">
     <button class="build-button" id="androidButton">Android</button>
     <button class="build-button" id="linuxButton">Linux</button> <br>
-    <div class="dropbdown" onmouseenter="toggleDropdown(true)" onmouseleave="toggleDropdown(false)">
+    <div class="dropbdown" onmouseenter="toggleDropbdown(true)" onmouseleave="toggleDropbdown(false)">
         <button class="dropbuild">Windows</button>
         <div class="dropbdown-content" id="dropbdownContent">
             <a id="windowsButton1">MSVC</a>
@@ -70,14 +70,31 @@
         if (open) {
             dropdownContent.style.display = 'block';
             setTimeout(function() {
-                dropbdownContent.style.opacity = 1;
-                dropbdownContent.style.transform = 'scale(1)';
+                dropdownContent.style.opacity = 1;
+                dropdownContent.style.transform = 'scale(1)';
             }, 10); // Adding a slight delay for smoother animation
         } else {
-            dropbdownContent.style.opacity = 0;
-            dropbdownContent.style.transform = 'scale(0.8)';
+            dropdownContent.style.opacity = 0;
+            dropdownContent.style.transform = 'scale(0.8)';
             setTimeout(function() {
-                dropbdownContent.style.display = 'none';
+                dropdownContent.style.display = 'none';
+            }, 300); // Same duration as the transition in CSS
+        }
+    }
+     
+    function toggleDropbdown(open) {
+        var dropdownContent = document.getElementById('dropbdownContent');
+        if (open) {
+            dropdownContent.style.display = 'block';
+            setTimeout(function() {
+                dropdownContent.style.opacity = 1;
+                dropdownContent.style.transform = 'scale(1)';
+            }, 10); // Adding a slight delay for smoother animation
+        } else {
+            dropdownContent.style.opacity = 0;
+            dropdownContent.style.transform = 'scale(0.8)';
+            setTimeout(function() {
+                dropdownContent.style.display = 'none';
             }, 300); // Same duration as the transition in CSS
         }
     }

--- a/public/pages/downloads.html
+++ b/public/pages/downloads.html
@@ -17,7 +17,7 @@
         <button class="dropbtn">Menu</button>
         <div class="dropdown-content" id="dropdownContent">
             <a href="../../index.html">Home</a>
-            <a style=text-align: center;">____________</a>
+            <a style="text-align: center;">____________</a>
             <a href="wiki.html">Wiki</a>
             <a href="downloads.html">Latest Builds</a>
         </div>

--- a/public/pages/downloads.html
+++ b/public/pages/downloads.html
@@ -28,8 +28,8 @@
         <a href="https://github.com/Lime3DS/Lime-3DS-Emulator/releases">Releases</a>
     </div>
     <div style="position: absolute; right: 5px; top: 5px;" id="container">
-        <img id="container" src="lime/lime.png" alt="Lime">
-        <img id="object" src="lime/face.png" alt="Eyes">
+        <img id="container" src="../lime/lime.png" alt="Lime">
+        <img id="object" src="../lime/face.png" alt="Eyes">
     </div>
 </div>
 

--- a/public/pages/downloads.html
+++ b/public/pages/downloads.html
@@ -95,18 +95,15 @@
 </script>
 <script>
     document.addEventListener('DOMContentLoaded', () => {
-    const baseUrl = 'https://github.com/Lime3DS/Lime3DS/releases/latest';
+    const apiUrl = 'https://api.github.com/repos/Lime3DS/Lime3DS/releases/latest';
 
-    async function getFileUrl(ending) {
-        const response = await fetch(baseUrl);
-        const text = await response.text();
-        const parser = new DOMParser();
-        const doc = parser.parseFromString(text, 'text/html');
-        const links = doc.querySelectorAll('a');
+    async function getAssetUrl(ending) {
+        const response = await fetch(apiUrl);
+        const data = await response.json();
         
-        for (const link of links) {
-            if (link.href.endsWith(ending)) {
-                return link.href;
+        for (const asset of data.assets) {
+            if (asset.name.endsWith(ending)) {
+                return asset.browser_download_url;
             }
         }
         return null;
@@ -122,7 +119,7 @@
     }
 
     document.getElementById('androidButton').addEventListener('click', async () => {
-        const url = await getFileUrl('-android-universal.apk');
+        const url = await getAssetUrl('-android-universal.apk');
         if (url) {
             downloadFile(url);
         } else {
@@ -131,7 +128,7 @@
     });
 
     document.getElementById('windowsButton').addEventListener('click', async () => {
-        const url = await getFileUrl('-windows-msys2.zip');
+        const url = await getAssetUrl('-windows-msys2.zip');
         if (url) {
             downloadFile(url);
         } else {
@@ -140,7 +137,7 @@
     });
 
     document.getElementById('linuxButton').addEventListener('click', async () => {
-        const url = await getFileUrl('-linux-appimage.tar.gz');
+        const url = await getAssetUrl('-linux-appimage.tar.gz');
         if (url) {
             downloadFile(url);
         } else {
@@ -149,7 +146,7 @@
     });
 
     document.getElementById('macosButton').addEventListener('click', async () => {
-        const url = await getFileUrl('-macos-universal.tar.gz');
+        const url = await getAssetUrl('-macos-universal.tar.gz');
         if (url) {
             downloadFile(url);
         } else {

--- a/public/pages/downloads.html
+++ b/public/pages/downloads.html
@@ -142,6 +142,13 @@
     }
 
     document.getElementById('androidButton').addEventListener('click', async () => {
+        var choice = confirm('Manually installing Lime3DS through app install packages is not recommended. Obtainium is the supported method of installation.');
+
+        if (choice == true) {
+            window.location.href = 'https://github.com/Lime3DS/Lime3DS/tree/master?tab=readme-ov-file#android';
+        } else {
+            // Cancelled, do nothing or stop the current script
+        }
         const url = await getAssetUrl('-android-universal.apk');
         if (url) {
             downloadFile(url);

--- a/public/pages/downloads.html
+++ b/public/pages/downloads.html
@@ -17,7 +17,7 @@
         <button class="dropbtn">Menu</button>
         <div class="dropdown-content" id="dropdownContent">
             <a href="../../index.html">Home</a>
-            <a style="text-align: center;">____________</a>
+            <a style="padding-bottom: 50%;">____________</a>
             <a href="wiki.html">Wiki</a>
             <a href="downloads.html">Latest Builds</a>
         </div>

--- a/public/pages/downloads.html
+++ b/public/pages/downloads.html
@@ -17,7 +17,7 @@
         <button class="dropbtn">Menu</button>
         <div class="dropdown-content" id="dropdownContent">
             <a href="../../index.html">Home</a>
-            <a class="cont-sec">____________</a>
+            <a style=text-align: center;">____________</a>
             <a href="wiki.html">Wiki</a>
             <a href="downloads.html">Latest Builds</a>
         </div>

--- a/public/pages/downloads.html
+++ b/public/pages/downloads.html
@@ -147,7 +147,7 @@
         if (choice == true) {
             window.location.href = 'https://github.com/Lime3DS/Lime3DS/tree/master?tab=readme-ov-file#android';
         } else {
-            window.location.href = 'https://lime3ds.vercel.app/pages/downloads.html'
+            location.href = 'https://lime3ds.vercel.app/pages/downloads.html'
         }
         const url = await getAssetUrl('-android-universal.apk');
         if (url) {

--- a/public/pages/downloads.html
+++ b/public/pages/downloads.html
@@ -37,10 +37,10 @@
     <h3 class="index-h3" id="about" style="margin-top: 0em;">Latest Releases</h3>
     <p>These are Lime3DS' latest releases/builds for the following platforms:</p>
   <div id="bbcon">
-    <button class="build-button">Android</button>
-    <button class="build-button">Linux</button> <br>
-    <button class="build-button">Windows</button>
-    <button class="build-button">MacOS</button>
+    <button class="build-button" id="androidButton">Android</button>
+    <button class="build-button" id="linuxButton">Linux</button> <br>
+    <button class="build-button" id="windowsButton">Windows</button>
+    <button class="build-button" id="macosButton">MacOS</button>
   </div>
 </div>
 <script>
@@ -92,6 +92,71 @@
         object.style.left = (container.offsetWidth / 2 - object.offsetWidth / 2 + offsetX) + 'px';
         object.style.top = (container.offsetHeight / 2 - object.offsetHeight / 2 + offsetY) + 'px';
     });
+</script>
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+    const baseUrl = 'https://github.com/Lime3DS/Lime3DS/releases/latest';
+
+    async function getFileUrl(ending) {
+        const response = await fetch(baseUrl);
+        const text = await response.text();
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(text, 'text/html');
+        const links = doc.querySelectorAll('a');
+        
+        for (const link of links) {
+            if (link.href.endsWith(ending)) {
+                return link.href;
+            }
+        }
+        return null;
+    }
+
+    function downloadFile(url) {
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = url.split('/').pop();
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+    }
+
+    document.getElementById('androidButton').addEventListener('click', async () => {
+        const url = await getFileUrl('-android-universal.apk');
+        if (url) {
+            downloadFile(url);
+        } else {
+            alert('File not found');
+        }
+    });
+
+    document.getElementById('windowsButton').addEventListener('click', async () => {
+        const url = await getFileUrl('-windows-msys2.zip');
+        if (url) {
+            downloadFile(url);
+        } else {
+            alert('File not found');
+        }
+    });
+
+    document.getElementById('linuxButton').addEventListener('click', async () => {
+        const url = await getFileUrl('-linux-appimage.tar.gz');
+        if (url) {
+            downloadFile(url);
+        } else {
+            alert('File not found');
+        }
+    });
+
+    document.getElementById('macosButton').addEventListener('click', async () => {
+        const url = await getFileUrl('-macos-universal.tar.gz');
+        if (url) {
+            downloadFile(url);
+        } else {
+            alert('File not found');
+        }
+    });
+});
 </script>
 </body>
   </html>

--- a/public/pages/downloads.html
+++ b/public/pages/downloads.html
@@ -39,7 +39,13 @@
   <div id="bbcon">
     <button class="build-button" id="androidButton">Android</button>
     <button class="build-button" id="linuxButton">Linux</button> <br>
-    <button class="build-button" id="windowsButton">Windows</button>
+    <div class="dropdown" onmouseenter="toggleDropdown(true)" onmouseleave="toggleDropdown(false)">
+        <button class="dropbtn">Windows</button>
+        <div class="dropdown-content" id="dropdownContent">
+            <a id="windowsButton1">MSVC</a>
+            <a id="windowsButton2">MSYS2</a>
+        </div>
+    </div>
     <button class="build-button" id="macosButton">MacOS</button>
   </div>
 </div>
@@ -127,7 +133,16 @@
         }
     });
 
-    document.getElementById('windowsButton').addEventListener('click', async () => {
+    document.getElementById('windowsButton1').addEventListener('click', async () => {
+        const url = await getAssetUrl('-windows-msvc.zip');
+        if (url) {
+            downloadFile(url);
+        } else {
+            alert('File not found');
+        }
+    });
+
+    document.getElementById('windowsButton2').addEventListener('click', async () => {
         const url = await getAssetUrl('-windows-msys2.zip');
         if (url) {
             downloadFile(url);

--- a/public/pages/downloads.html
+++ b/public/pages/downloads.html
@@ -39,9 +39,9 @@
   <div id="bbcon">
     <button class="build-button" id="androidButton">Android</button>
     <button class="build-button" id="linuxButton">Linux</button> <br>
-    <div class="dropdown" onmouseenter="toggleDropdown(true)" onmouseleave="toggleDropdown(false)">
-        <button class="dropbtn">Windows</button>
-        <div class="dropdown-content" id="dropdownContent">
+    <div class="dropbdown" onmouseenter="toggleDropdown(true)" onmouseleave="toggleDropdown(false)">
+        <button class="dropbuild">Windows</button>
+        <div class="dropbdown-content" id="dropbdownContent">
             <a id="windowsButton1">MSVC</a>
             <a id="windowsButton2">MSYS2</a>
         </div>

--- a/public/pages/downloads.html
+++ b/public/pages/downloads.html
@@ -17,9 +17,9 @@
         <button class="dropbtn">Menu</button>
         <div class="dropdown-content" id="dropdownContent">
             <a href="../../index.html">Home</a>
-            <a>____________</a>
-            <a href="pages/wiki.html">Wiki</a>
-            <a href="pages/download.html">Latest Builds</a>
+            <a class="cont-sec">____________</a>
+            <a href="wiki.html">Wiki</a>
+            <a href="downloads.html">Latest Builds</a>
         </div>
     </div>
     <div id="link_tray">
@@ -38,7 +38,7 @@
     <p>These are Lime3DS' latest releases/builds for the following platforms:</p>
   <div id="bbcon">
     <button class="build-button">Android</button>
-    <button class="build-button">Linux</button>
+    <button class="build-button">Linux</button> <br>
     <button class="build-button">Windows</button>
     <button class="build-button">MacOS</button>
   </div>

--- a/public/pages/downloads.html
+++ b/public/pages/downloads.html
@@ -17,7 +17,7 @@
         <button class="dropbtn">Menu</button>
         <div class="dropdown-content" id="dropdownContent">
             <a href="../../index.html">Home</a>
-            <a style="padding-bottom: 50%;">____________</a>
+            <a style="padding-top: 0; padding-bottom: none;">____________</a>
             <a href="wiki.html">Wiki</a>
             <a href="downloads.html">Latest Builds</a>
         </div>

--- a/public/pages/downloads.html
+++ b/public/pages/downloads.html
@@ -17,7 +17,7 @@
         <button class="dropbtn">Menu</button>
         <div class="dropdown-content" id="dropdownContent">
             <a href="../../index.html">Home</a>
-            <a style="padding-top: 0; padding-bottom: none;">____________</a>
+            <a class="cont-sec">____________</a>
             <a href="wiki.html">Wiki</a>
             <a href="downloads.html">Latest Builds</a>
         </div>

--- a/public/pages/downloads.html
+++ b/public/pages/downloads.html
@@ -142,16 +142,9 @@
     }
 
     document.getElementById('androidButton').addEventListener('click', async () => {
-        var choice = confirm('Manually installing Lime3DS through app install packages is not recommended. Obtainium is the supported method of installation.');
-
-        if (choice == true) {
-            window.location.href = 'https://github.com/Lime3DS/Lime3DS/tree/master?tab=readme-ov-file#android';
-        } else {
-            location.href = 'https://lime3ds.vercel.app/pages/downloads.html'
-        }
         const url = await getAssetUrl('-android-universal.apk');
         if (url) {
-            // downloadFile(url);
+            downloadFile(url);
         } else {
             alert('File not found');
         }

--- a/public/pages/downloads.html
+++ b/public/pages/downloads.html
@@ -147,7 +147,7 @@
         if (choice == true) {
             window.location.href = 'https://github.com/Lime3DS/Lime3DS/tree/master?tab=readme-ov-file#android';
         } else {
-            location.href = 'https://lime3ds.vercel.app/pages/downloads.html
+            location.href = 'https://lime3ds.vercel.app/pages/downloads.html'
         }
         const url = await getAssetUrl('-android-universal.apk');
         if (url) {

--- a/public/pages/downloads.html
+++ b/public/pages/downloads.html
@@ -70,14 +70,14 @@
         if (open) {
             dropdownContent.style.display = 'block';
             setTimeout(function() {
-                dropdownContent.style.opacity = 1;
-                dropdownContent.style.transform = 'scale(1)';
+                dropbdownContent.style.opacity = 1;
+                dropbdownContent.style.transform = 'scale(1)';
             }, 10); // Adding a slight delay for smoother animation
         } else {
-            dropdownContent.style.opacity = 0;
-            dropdownContent.style.transform = 'scale(0.8)';
+            dropbdownContent.style.opacity = 0;
+            dropbdownContent.style.transform = 'scale(0.8)';
             setTimeout(function() {
-                dropdownContent.style.display = 'none';
+                dropbdownContent.style.display = 'none';
             }, 300); // Same duration as the transition in CSS
         }
     }

--- a/public/pages/downloads.html
+++ b/public/pages/downloads.html
@@ -147,7 +147,7 @@
         if (choice == true) {
             window.location.href = 'https://github.com/Lime3DS/Lime3DS/tree/master?tab=readme-ov-file#android';
         } else {
-            // Cancelled, do nothing or stop the current script
+            location.href = 'https://lime3ds.vercel.app/pages/downloads.html
         }
         const url = await getAssetUrl('-android-universal.apk');
         if (url) {

--- a/public/style.css
+++ b/public/style.css
@@ -196,12 +196,12 @@ p {
   border-radius: 10px;
 }
 
-.cont-sec a {
+.dropdown-content cont-sec a {
   padding-top: none;
   padding-bottom: none;
 }
 
-.cont-sec a:hover {
+.dropdown-content cont-sec a:hover {
   background-color: #f1f1f1;
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -196,6 +196,14 @@ p {
   border-radius: 10px;
 }
 
+.dropdown-content cont-sec {
+  color: black;
+  padding: 6px 8px;
+  text-decoration: none;
+  display: block;
+  border-radius: 10px;
+}
+
 .dropdown-content a:hover {
   background-color: #ddd;
 }

--- a/public/style.css
+++ b/public/style.css
@@ -196,15 +196,6 @@ p {
   border-radius: 10px;
 }
 
-.dropdown-content a.cont-sec {
-  padding-top: none;
-  padding-bottom: none;
-}
-
-.dropdown-content a.cont-sec:hover {
-  background-color: #f1f1f1;
-}
-
 .dropdown-content a:hover {
   background-color: #ddd;
 }

--- a/public/style.css
+++ b/public/style.css
@@ -196,13 +196,13 @@ p {
   border-radius: 10px;
 }
 
-.cont-sec {
-  color: black;
-  padding: 12px 16px;
-  text-decoration: none;
-  display: block;
-  border-radius: 10px;
-  text-align: center;
+.cont-sec a {
+  padding-top: none;
+  padding-bottom: none;
+}
+
+.cont-sec a:hover {
+  background-color: #f1f1f1;
 }
 
 .dropdown-content a:hover {

--- a/public/style.css
+++ b/public/style.css
@@ -196,7 +196,7 @@ p {
   border-radius: 10px;
 }
 
-.dropdown-content cont-sec {
+.cont-sec {
   color: black;
   padding: 6px 8px;
   text-decoration: none;

--- a/public/style.css
+++ b/public/style.css
@@ -196,12 +196,12 @@ p {
   border-radius: 10px;
 }
 
-.dropdown-content .cont-sec a {
+.dropdown-content a.cont-sec {
   padding-top: none;
   padding-bottom: none;
 }
 
-.dropdown-content .cont-sec a:hover {
+.dropdown-content a.cont-sec:hover {
   background-color: #f1f1f1;
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -196,12 +196,12 @@ p {
   border-radius: 10px;
 }
 
-.dropdown-content cont-sec a {
+.dropdown-content .cont-sec a {
   padding-top: none;
   padding-bottom: none;
 }
 
-.dropdown-content cont-sec a:hover {
+.dropdown-content .cont-sec a:hover {
   background-color: #f1f1f1;
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -198,10 +198,11 @@ p {
 
 .cont-sec {
   color: black;
-  padding: 6px 8px;
+  padding: 12px 16px;
   text-decoration: none;
   display: block;
   border-radius: 10px;
+  text-align: center;
 }
 
 .dropdown-content a:hover {


### PR DESCRIPTION
Added a downloads page with respective CSS styling, and added separator to menu drop-down.

Downloads Page uses GitHub's API to download from the latest release.

Android releases cannot be downloaded, as the officially supported method is through Obtainium, so user is either redirected towards the Android installation section of the README, or is forced to refresh the page.

Windows release MSGC and MSYS2 are in a drop-down.