### PR TITLE
Add downloads page

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
         <button class="dropbtn">Menu</button>
         <div class="dropdown-content" id="dropdownContent">
             <a href="pages/wiki.html">Wiki</a>
+            <a href="pages/downloads.html">Latest Builds</a>
         </div>
     </div>
     <div id="link_tray">

--- a/pages/downloads.css
+++ b/pages/downloads.css
@@ -1,0 +1,25 @@
+body {
+    font-family: 'Ubuntu', sans-serif;
+}
+
+#bbcon {
+  margin: 12px auto;
+}
+
+.build-button {
+  background-color: #111111;
+  color: white;
+  padding: 12px 17px;
+  font-size: 16px;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  display: inline;
+  margin: 12px auto;
+  font-family: 'Ubuntu', sans-serif;
+}
+
+.build-button:hover,
+.build-button:focus {
+  background-color: #333333;
+}

--- a/pages/downloads.html
+++ b/pages/downloads.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Latest Releases</title>
+    <link rel="icon" href="../favicon.ico" type="image/x-icon">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Ubuntu&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../style.css">
+    <link rel="stylesheet" href="downloads.css">
+</head>
+<body>
+<div id="header">
+    <div class="dropdown" onmouseenter="toggleDropdown(true)" onmouseleave="toggleDropdown(false)">
+        <button class="dropbtn">Menu</button>
+        <div class="dropdown-content" id="dropdownContent">
+            <a href="../index.html">Home</a>
+            <a style="padding-top: none; padding-bottom: none;">____________</a>
+            <a href="wiki.html">Wiki</a>
+            <a href="downloads.html">Latest Builds</a>
+        </div>
+    </div>
+    <div id="link_tray">
+        <a href="https://github.com/Lime3DS/Lime-3DS-Emulator">GitHub</a> |
+        <a href="https://discord.com/invite/4ZjMpAp3M6">Discord</a> |
+        <a href="https://github.com/Lime3DS/Lime-3DS-Emulator/releases">Releases</a>
+    </div>
+    <div style="position: absolute; right: 5px; top: 5px;" id="container">
+        <img id="container" src="../lime/lime.png" alt="Lime">
+        <img id="object" src="../lime/face.png" alt="Eyes">
+    </div>
+</div>
+
+<div id="content">
+    <h3 class="index-h3" id="about" style="margin-top: 0em;">Latest Releases</h3>
+    <p>These are Lime3DS' latest releases/builds for the following platforms:</p>
+  <div id="bbcon">
+    <h3 class="index-h3" style="font-size: 1em;">Normal Builds</h3>
+    <button class="build-button" id="androidButton">Android</button>
+    <button class="build-button" id="linuxButton">Linux</button>
+    <button class="build-button" id="macosButton">MacOS</button> <br>
+    <h3 class="index-h3" style="font-size: 1em;">Windows Builds</h3>
+    <button class="build-button" id="windowsButton1">Windows MSVC</button>
+    <button class="build-button" id="windowsButton2">Windows MSYS2</button>
+  </div>
+</div>
+<script>
+    // Preload images
+    var images = ['lime/face.png', 'lime/smile.png'];
+    preloadImages(images);
+
+    function preloadImages(array) {
+        if (!preloadImages.list) {
+            preloadImages.list = [];
+        }
+        for (var i = 0; i < array.length; i++) {
+            var img = new Image();
+            img.src = array[i];
+            preloadImages.list.push(img);
+        }
+    }
+
+    function toggleDropdown(open) {
+        var dropdownContent = document.getElementById('dropdownContent');
+        if (open) {
+            dropdownContent.style.display = 'block';
+            setTimeout(function() {
+                dropdownContent.style.opacity = 1;
+                dropdownContent.style.transform = 'scale(1)';
+            }, 10); // Adding a slight delay for smoother animation
+        } else {
+            dropdownContent.style.opacity = 0;
+            dropdownContent.style.transform = 'scale(0.8)';
+            setTimeout(function() {
+                dropdownContent.style.display = 'none';
+            }, 300); // Same duration as the transition in CSS
+        }
+    }
+     
+    function toggleDropbdown(open) {
+        var dropdownContent = document.getElementById('dropbdownContent');
+        if (open) {
+            dropdownContent.style.display = 'block';
+            setTimeout(function() {
+                dropdownContent.style.opacity = 1;
+                dropdownContent.style.transform = 'scale(1)';
+            }, 10); // Adding a slight delay for smoother animation
+        } else {
+            dropdownContent.style.opacity = 0;
+            dropdownContent.style.transform = 'scale(0.8)';
+            setTimeout(function() {
+                dropdownContent.style.display = 'none';
+            }, 300); // Same duration as the transition in CSS
+        }
+    }
+
+    document.addEventListener('mousemove', function (e) {
+        var object = document.getElementById('object');
+        var container = document.getElementById('container');
+
+        // Calculate the position of the cursor relative to the container
+        var mouseX = e.clientX - container.getBoundingClientRect().left;
+        var mouseY = e.clientY - container.getBoundingClientRect().top;
+
+        // Calculate the position of the eyes relative to the cursor position within the lime container
+        var offsetX = (mouseX - (container.offsetWidth / 2)) * 0.0025; // Adjust the factor to control eye movement
+        var offsetY = (mouseY - (container.offsetHeight / 2)) * 0.0025; // Adjust the factor to control eye movement
+
+        // Set the position of the eyes
+        object.style.left = (container.offsetWidth / 2 - object.offsetWidth / 2 + offsetX) + 'px';
+        object.style.top = (container.offsetHeight / 2 - object.offsetHeight / 2 + offsetY) + 'px';
+    });
+</script>
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+    const apiUrl = 'https://api.github.com/repos/Lime3DS/Lime3DS/releases/latest';
+
+    async function getAssetUrl(ending) {
+        const response = await fetch(apiUrl);
+        const data = await response.json();
+        
+        for (const asset of data.assets) {
+            if (asset.name.endsWith(ending)) {
+                return asset.browser_download_url;
+            }
+        }
+        return null;
+    }
+
+    function downloadFile(url) {
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = url.split('/').pop();
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+    }
+
+    document.getElementById('androidButton').addEventListener('click', async () => {
+        const url = await getAssetUrl('-android-universal.apk');
+        if (url) {
+            downloadFile(url);
+        } else {
+            alert('File not found');
+        }
+    });
+
+    document.getElementById('windowsButton1').addEventListener('click', async () => {
+        const url = await getAssetUrl('-windows-msvc.zip');
+        if (url) {
+            downloadFile(url);
+        } else {
+            alert('File not found');
+        }
+    });
+
+    document.getElementById('windowsButton2').addEventListener('click', async () => {
+        const url = await getAssetUrl('-windows-msys2.zip');
+        if (url) {
+            downloadFile(url);
+        } else {
+            alert('File not found');
+        }
+    });
+
+    document.getElementById('linuxButton').addEventListener('click', async () => {
+        const url = await getAssetUrl('-linux-appimage.tar.gz');
+        if (url) {
+            downloadFile(url);
+        } else {
+            alert('File not found');
+        }
+    });
+
+    document.getElementById('macosButton').addEventListener('click', async () => {
+        const url = await getAssetUrl('-macos-universal.tar.gz');
+        if (url) {
+            downloadFile(url);
+        } else {
+            alert('File not found');
+        }
+    });
+});
+</script>
+</body>
+  </html>


### PR DESCRIPTION
Original PR by @LutraVibes

> I cooked again.
> 
> It uses GitHub's release download API to download the most recent builds of the user selected type.
> 
> All downloads are available (except for source code that can be grabbed from the releases tab, in the link tray), and there are two sections for normal builds and Windows builds.

The changes from the previous 63(?!) commits have been squashed into a single commit for easier viewing